### PR TITLE
Bump @graphql-tools/url-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@graphql-tools/graphql-file-loader": "^6.2.5",
     "@graphql-tools/json-file-loader": "^6.2.5",
     "@graphql-tools/load": "^6.2.5",
-    "@graphql-tools/url-loader": "^6.4.0",
+    "@graphql-tools/url-loader": "^7.9.0",
     "@graphql-tools/utils": "^6.2.4",
     "graphql": "^15.4.0",
     "yargs": "^15.4.1"


### PR DESCRIPTION
Fixes [security issue](https://github.com/advisories/GHSA-7gc6-qh9x-w6h8):

```
# npm audit report

cross-fetch  <=2.2.3 || 2.2.5 || 3.0.0 - 3.1.4 || >=3.2.0-alpha.0
Severity: high
Incorrect Authorization in cross-fetch - https://github.com/advisories/GHSA-7gc6-qh9x-w6h8
Depends on vulnerable versions of node-fetch
No fix available
node_modules/generate-graphql-operations/node_modules/cross-fetch
  @graphql-tools/url-loader  <=7.4.3-alpha-9f8b9c45.0
  Depends on vulnerable versions of cross-fetch
  Depends on vulnerable versions of ws
  node_modules/generate-graphql-operations/node_modules/@graphql-tools/url-loader
    generate-graphql-operations  *
    Depends on vulnerable versions of @graphql-tools/url-loader
```